### PR TITLE
fix github_id mysql error

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -18,6 +18,7 @@ class CreateUsersTable extends Migration
             $table->string('name');
             $table->string('nickname');
             $table->string('email')->unique();
+            $table->string('github_id')->unique();
             $table->string('avatar');
             $table->string('html_url');
             $table->string('type');


### PR DESCRIPTION
#### What does this PR do?
Fix Error 

> SQLSTATE[42S22]: Column not found: 1054 Unknown column 'github_id' in 'where clause' (SQL: select * from `users` where `github_id` = xxxxxx limit 1)


#### Background Context?
In OSX, trying to register with github produces the above error. 

PHP Version: 7.1.7 
Laravel Framework 5.5.28

The error can be reproduced by simply following the installation guide. After starting the server, click on **`Register with Github`**

I don't know if the error is peculiar to my machine anyway. 